### PR TITLE
增加labelOverlay的offsets属性，增加imageOverlay的label属性，与mouseOver及selected样式

### DIFF
--- a/examples/ImgOverlay-SetOptionStyle.html
+++ b/examples/ImgOverlay-SetOptionStyle.html
@@ -27,8 +27,7 @@
 
     <script type="text/javascript" src="http://api.map.baidu.com/api?v=3.0&ak=U3q69k0Dv0GCYNiiZeHPf7BS"></script>
     <script src="../dist/inmap.js"></script>
-    <script src="data/data.js"></script>
-
+    <script src="data/data2.js"></script>
 </head>
 
 <body>
@@ -37,7 +36,7 @@
 
 </html>
 <script>
-    data.length = 5;
+    data.length = 50;
     var map = new inMap.Map({
         id: 'allmap',
         center: [105.403119, 38.028658],
@@ -51,6 +50,7 @@
     var img = "./img/bso.svg";
     var img2 = "./img/mark (2).png";
     var img3 = "./img/place.svg";
+
     var overlay = new inMap.ImgOverlay({
         tooltip: {
             show: true,
@@ -66,18 +66,45 @@
                 offsets: {
                     top: "-100%",
                     left: "-50%",
-                }
+                },
+                label: {
+                    show: true,
+                    font: '12px bold ',
+                    color: '#fff',
+                    offsets: {
+                        top: -22,
+                        left: 0
+                    }
+                },
             },
-            splitList: [{ //设置区间颜色
+            splitList: [
+                { //设置区间颜色
                     start: 0,
                     end: 2,
-                    icon: img,
+                    icon: img3,
+                    label: {
+                        show: true,
+                        font: '12px bold ',
+                        color: '#000',
+                        offsets: {
+                            top: -25,
+                            left: 0
+                        }
+                    },
                 },
                 {
                     start: 2,
                     end: 5,
                     icon: img2,
-
+                    label: {
+                        show: true,
+                        font: '12px bold ',
+                        color: '#fff',
+                        offsets: {
+                            top: -25,
+                            left: 4
+                        }
+                    },
                 },
                 {
                     start: 5,
@@ -94,26 +121,26 @@
     });
     map.add(overlay);
 
-    setTimeout(() => {
-        overlay.setOptionStyle({
-            skin: "Blueness",
-            tooltip: {
-                show: true,
-                formatter: function (params) {
-                    return params.count;
-                }
-            },
-            style: {
-                normal: {
-                    icon: img3,
-                    width: 40,
-                    height: 40,
-                    offsets: {
-                        top: "-100%",
-                        left: "-50%",
-                    }
-                }
-            }
-        });
-    }, 2000);
+    // setTimeout(() => {
+    //     overlay.setOptionStyle({
+    //         skin: "Blueness",
+    //         tooltip: {
+    //             show: true,
+    //             formatter: function (params) {
+    //                 return params.count;
+    //             }
+    //         },
+    //         style: {
+    //             normal: {
+    //                 icon: img,
+    //                 width: 40,
+    //                 height: 40,
+    //                 offsets: {
+    //                     top: "-100%",
+    //                     left: "-50%",
+    //                 }
+    //             }
+    //         }
+    //     });
+    // }, 2000);
 </script>

--- a/examples/ImgOverlay-SetOptionStyle.html
+++ b/examples/ImgOverlay-SetOptionStyle.html
@@ -67,12 +67,21 @@
                     top: "-100%",
                     left: "-50%",
                 },
+
+            },
+            mouseOver: {
+                icon: img,
+                width: 80,
+                height: 80,
+                offsets: {
+                    top: "-100%",
+                    left: "-50%",
+                },
                 label: {
-                    show: true,
-                    font: '12px bold ',
+                    font: '14px bold ',
                     color: '#fff',
                     offsets: {
-                        top: -22,
+                        top: -44,
                         left: 0
                     }
                 },
@@ -116,6 +125,18 @@
                     icon: img,
                 }
             ],
+        },
+        event: {
+            onMouseClick: function (item) {
+                //能获取当前点的信息
+                console.log(item,11111);
+            },
+            onMouseOver:function(item,event,overlay){
+                // console.log(item,event,overlay);
+            },
+            onState(state) {
+                console.log(state);
+            }
         },
         data: data
     });

--- a/examples/LabelOverlay.html
+++ b/examples/LabelOverlay.html
@@ -61,7 +61,11 @@
                 font: '18px Arial',
                 color: 'rgba(255, 250, 50, 1)',
                 shadowColor: 'rgba(255, 250, 50, 1)',
-                shadowBlur: 10
+                shadowBlur: 10,
+                offsets: {
+                    top: -20,
+                    left: 0
+                }
             },
             mouseOver: {
                 color: 'rgba(255, 250, 255, 1)',

--- a/src/config/ImgConfig.js
+++ b/src/config/ImgConfig.js
@@ -16,6 +16,15 @@ export default {
             icon: null,
             width: 0,
             height: 0,
+            label: {
+                show: false,
+                font: '12px bold ',
+                color: '#fff',
+                offsets: {
+                    top: 0,
+                    left: 0
+                }
+            },
             offsets: {
                 top: 0,
                 left: 0

--- a/src/config/LabelConfig.js
+++ b/src/config/LabelConfig.js
@@ -16,7 +16,11 @@ export default {
             font: '18px Arial',
             color: 'yellow',
             shadowColor: 'yellow',
-            shadowBlur: 10
+            shadowBlur: 10,
+            offsets: {
+                top: 0,
+                left: 0
+            }
         },
         splitList: [],
         colors: []

--- a/src/overlay/HeatOverlay.js
+++ b/src/overlay/HeatOverlay.js
@@ -76,7 +76,7 @@ export default class HeatOverlay extends CanvasOverlay {
         if (this._workerData.length == 0) {
             return 0;
         }
-        let maxValue =0;
+        let maxValue = this._workerData[0].count;
         for (let i = 0, len = this._workerData.length; i < len; i++) {
             if (this._workerData[i].count > maxValue) {
                 maxValue = this._workerData[i].count;
@@ -90,7 +90,7 @@ export default class HeatOverlay extends CanvasOverlay {
             return 0;
         }
         
-        let minValue = 0;
+        let minValue = this._workerData[0].count;
         for (let i = 0, len = this._workerData.length; i < len; i++) {
             if (this._workerData[i].count < minValue) {
                 minValue = this._workerData[i].count;

--- a/src/overlay/ImgOverlay.js
+++ b/src/overlay/ImgOverlay.js
@@ -106,10 +106,11 @@ export default class ImgOverlay extends Parameter {
         let index = -1;
         if (item) {
             index = this._selectItem.findIndex(function (val) {
-                return val && val.lat == item.lat && val.lng == item.lng;
+                let itemCoordinates = item.geometry.coordinates;
+                let valCoordinates = val.geometry.coordinates;
+                return val && itemCoordinates[0] == valCoordinates[0] && itemCoordinates[1] == valCoordinates[1] && val.count == item.count;
             });
         }
-
         return index;
     }
     refresh() {
@@ -169,45 +170,12 @@ export default class ImgOverlay extends Parameter {
             y: y
         };
     }
-    /**
-     * 根据用户配置，设置用户绘画样式
-     * @param {*} item
-     */
-    _setDrawStyle(item, i) {
-        let normal = this._styleConfig.normal; //正常样式
-        let result = merge({}, normal);
-        let count = parseFloat(item.count);
-
-        //区间样式
-        let splitList = this._styleConfig.splitList,
-            len = splitList.length;
-        len = splitList.length;
-        if (len > 0 && typeOf(count) !== 'number') {
-            throw new TypeError(`inMap: data index Line ${i}, The property count must be of type Number! about geoJSON, visit http://inmap.talkingdata.com/#/docs/v2/Geojson`);
-        }
-        for (let i = 0; i < len; i++) {
-            let condition = splitList[i];
-            if (condition.end == null) {
-                if (count >= condition.start) {
-                    Object.assign(result, normal, condition);
-                    break;
-                }
-            } else if (count >= condition.start && count < condition.end) {
-                Object.assign(result, normal, condition);
-                break;
-            }
-        }
-
-
-        return result;
-
-    }
     _loopDraw(ctx, pixels) {
         let mapSize = this._map.getSize();
         for (let i = 0, len = pixels.length; i < len; i++) {
             let item = pixels[i];
             let pixel = item.geometry.pixel;
-            let style = this._setDrawStyle(item, i);
+            let style = this._setDrawStyle(item, true, i);
             if (pixel.x > -style.width && pixel.y > -style.height && pixel.x < mapSize.width + style.width && pixel.y < mapSize.height + style.height) {
                 this._loadImg(style.icon, (img) => {
                     if (style.width && style.height) {

--- a/src/overlay/ImgOverlay.js
+++ b/src/overlay/ImgOverlay.js
@@ -70,7 +70,7 @@ export default class ImgOverlay extends Parameter {
                 img = style.icon;
             }
 
-            //img  Not Loaded return 
+            //img  Not Loaded return
             if (!img) break;
             if (style.width && style.height) {
                 let xy = this._getDrawXY(pixel, style.offsets.left, style.offsets.top, style.width, style.height, 1);
@@ -171,7 +171,7 @@ export default class ImgOverlay extends Parameter {
     }
     /**
      * 根据用户配置，设置用户绘画样式
-     * @param {*} item 
+     * @param {*} item
      */
     _setDrawStyle(item, i) {
         let normal = this._styleConfig.normal; //正常样式
@@ -217,6 +217,13 @@ export default class ImgOverlay extends Parameter {
                     } else {
                         let xy = this._getDrawXY(pixel, style.offsets.left, style.offsets.top, img.width, img.height, 1);
                         this._drawImage(this._ctx, img, xy.x, xy.y, img.width, img.height);
+                    }
+                    if(style.label.show){
+                        this._ctx.font = style.label.font;
+                        this._ctx.fillStyle = style.label.color;
+                        let width = this._ctx.measureText(item.name).width;
+                        let offsets = style.label.offsets;
+                        this._ctx.fillText(item.name, pixel.x - width/2 + offsets.left, pixel.y + parseInt(style.label.font)/2 + offsets.top);
                     }
                 });
             }

--- a/src/overlay/ImgOverlay.js
+++ b/src/overlay/ImgOverlay.js
@@ -223,7 +223,7 @@ export default class ImgOverlay extends Parameter {
                         this._ctx.fillStyle = style.label.color;
                         let width = this._ctx.measureText(item.name).width;
                         let offsets = style.label.offsets;
-                        this._ctx.fillText(item.name, pixel.x - width/2 + offsets.left, pixel.y + parseInt(style.label.font)/2 + offsets.top);
+                        this._ctx.fillText(item.name, pixel.x - width/2 + offsets.left, pixel.y + parseInt(style.label.font,10)/2 + offsets.top);
                     }
                 });
             }

--- a/src/overlay/LabelOverlay.js
+++ b/src/overlay/LabelOverlay.js
@@ -136,7 +136,7 @@ export default class LabelOverlay extends Parameter {
             }
 
             ctx.beginPath();
-            ctx.fillText(item.name, pixel.x - byteWidth / 2 + style.offsets.left, pixel.y + parseInt(style.font) / 2 + style.offsets.top);
+            ctx.fillText(item.name, pixel.x - byteWidth / 2 + style.offsets.left, pixel.y + parseInt(style.font,10) / 2 + style.offsets.top);
             ctx.fill();
         }
     }

--- a/src/overlay/LabelOverlay.js
+++ b/src/overlay/LabelOverlay.js
@@ -136,7 +136,7 @@ export default class LabelOverlay extends Parameter {
             }
 
             ctx.beginPath();
-            ctx.fillText(item.name, pixel.x - byteWidth / 2, pixel.y);
+            ctx.fillText(item.name, pixel.x - byteWidth / 2 + style.offsets.left, pixel.y + parseInt(style.font) / 2 + style.offsets.top);
             ctx.fill();
         }
     }


### PR DESCRIPTION
1.增加labelOverlay的offsets属性

```
offsets: {
    top: -22, //px，默认为0
    left: 0
}
```
2.增加imageOverlay的label属性，且在normal与splitList中均可填写 (splitList中的label属性会覆盖normal中的label属性)

```
label: {
    show: true,
    font: '12px bold ',
    color: '#fff',
    offsets: { //注意与整个image图标的offsets区分，此offsets是相对于图标的image来设置 label偏移
        top: -22,  //px，默认为0
        left: 0
    }
}
```